### PR TITLE
update load type checker to allow loading an existing media element

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react": ">=0.13"
   },
   "dependencies": {
-    "wavesurfer.js": "^1.0.58"
+    "wavesurfer.js": "^1.1.2"
   },
   "devDependencies": {
     "babel": "^6.0.x",

--- a/src/react-wavesurfer.js
+++ b/src/react-wavesurfer.js
@@ -52,6 +52,7 @@ class Wavesurfer extends Component {
     this._wavesurfer = Object.create(WaveSurfer);
     this._isReady = false;
     this._playing = false;
+
     this._loadAudio = this._loadAudio.bind(this);
     this._seekTo = this._seekTo.bind(this);
   }
@@ -61,6 +62,7 @@ class Wavesurfer extends Component {
       container: this.refs.wavesurfer
     });
 
+    window.console.log('options', options);
     this._wavesurfer.init(options);
 
     // file was loaded, wave was drawn, update the _fileLoaded flag
@@ -132,6 +134,11 @@ class Wavesurfer extends Component {
       this._loadAudio(nextProps.audioFile);
     }
 
+    if (this.props.peaks !== nextProps.peaks) {
+      const mediaElt = document.getElementById(this.props.mediaEltId);
+      this._loadAudio(mediaElt, nextProps.peaks);
+    }
+
     if (nextProps.pos &&
         this._isReady &&
         nextProps.pos !== this.props.pos &&
@@ -189,13 +196,16 @@ class Wavesurfer extends Component {
     }
   }
 
-  _loadAudio(audioFile) {
-    // blob or file is loaded with loadBlob method
-    if (audioFile instanceof Blob || audioFile instanceof File) {
-      this._wavesurfer.loadBlob(audioFile);
+  _loadAudio(audioFileOrElt, peaks) {
+    if (audioFileOrElt instanceof HTMLElement) {
+      // media element that may include an array of peaks
+      this._wavesurfer.loadMediaElement(audioFileOrElt, peaks);
+    } else if (audioFileOrElt instanceof Blob || audioFileOrElt instanceof File) {
+      // blob or file is loaded with loadBlob method
+      this._wavesurfer.loadBlob(audioFileOrElt);
     } else {
-      // HTML Media Elt or path to media file (handled by load method + ajax call)
-      this._wavesurfer.load(audioFile);
+      // path to media file (handled by load method + ajax call)
+      this._wavesurfer.load(audioFileOrElt);
     }
   }
 
@@ -229,6 +239,9 @@ Wavesurfer.propTypes = {
 
     return null;
   },
+
+  peaks: PropTypes.array,
+  mediaEltId: PropTypes.string,
 
   volume: PropTypes.number,
   zoom: PropTypes.number,
@@ -270,6 +283,8 @@ Wavesurfer.propTypes = {
 Wavesurfer.defaultProps = {
   playing: false,
   pos: 0,
+  mediaEltId: undefined,
+  peaks: [],
   audioFile: undefined,
   options: WaveSurfer.defaultParams,
   onPosChange: () => {}

--- a/src/react-wavesurfer.js
+++ b/src/react-wavesurfer.js
@@ -62,7 +62,6 @@ class Wavesurfer extends Component {
       container: this.refs.wavesurfer
     });
 
-    window.console.log('options', options);
     this._wavesurfer.init(options);
 
     // file was loaded, wave was drawn, update the _fileLoaded flag

--- a/src/react-wavesurfer.js
+++ b/src/react-wavesurfer.js
@@ -190,15 +190,12 @@ class Wavesurfer extends Component {
   }
 
   _loadAudio(audioFile) {
-    // bog-standard string is handled by load method and ajax call
-    if (typeof audioFile === 'string') {
-      this._wavesurfer.load(audioFile);
-    } else if (audioFile instanceof Blob || audioFile instanceof File) {
-      // blob or file is loaded with loadBlob method
+    // blob or file is loaded with loadBlob method
+    if (audioFile instanceof Blob || audioFile instanceof File) {
       this._wavesurfer.loadBlob(audioFile);
     } else {
-      throw new Error(`Wavesurfer._loadAudio expexts prop audioFile
-        to be either string or file/blob`);
+      // HTML Media Elt or path to media file (handled by load method + ajax call)
+      this._wavesurfer.load(audioFile);
     }
   }
 


### PR DESCRIPTION
Thanks for your work on this!

A [recent update to wavesurfer.js](https://github.com/katspaugh/wavesurfer.js/commit/4079d5467f864cb3284391cb987748619340f52c) allows `load` to be called with an HTML5 Media Element, instead of a String or binary data.

I'd like to make this work with react-wavesurfer. Let me know if this looks good or if I can make any tweaks!