### PR TITLE
Remove unneeded play/seek/pause in responsive redraw

### DIFF
--- a/src/react-wavesurfer.js
+++ b/src/react-wavesurfer.js
@@ -67,25 +67,8 @@ class Wavesurfer extends Component {
 
     if (this.props.responsive) {
       this._handleResize = resizeThrottler(() => {
-        // pause playback for resize operation
-        if (this.props.playing) {
-          this._wavesurfer.pause();
-        }
-
-        // resize the waveform
+        // resize/redraw the waveform
         this._wavesurfer.drawBuffer();
-
-        // We allow resize before file isloaded, since we can get wave data from outside,
-        // so there might not be a file loaded when resizing
-        if (this.state.isReady) {
-          // restore previous position
-          this._seekTo(this.props.pos);
-        }
-
-        // restore playback
-        if (this.props.playing) {
-          this._wavesurfer.play();
-        }
       });
     }
   }


### PR DESCRIPTION
Maybe I am missing something, but to me the current code looks like a left over from a [prior attempt to keep the current position][1] when redrawing. This was needed since there originally was a [call to `empty`][2] which reset the current position. This has since [been removed][3], making the play/seek/pause handling obsolete.

[1]: https://github.com/mspae/react-wavesurfer/commit/ff54576984638e678837537d5518bdcd4f5ed674#diff-b466660621e2fe4b9e74419c938ee00eL71
[2]: https://github.com/katspaugh/wavesurfer.js/blob/77783081cc62c27afdf2eca1f1dc6623e46cc08c/src/wavesurfer.js#L612
[3]: https://github.com/mspae/react-wavesurfer/commit/4fcd41c72481b0eca938c41b8f6b4b46bf655a72