### PR TITLE
[WIP] Improve responsive resize handling

### DIFF
--- a/src/react-wavesurfer.js
+++ b/src/react-wavesurfer.js
@@ -65,29 +65,11 @@ class Wavesurfer extends Component {
     this._loadAudio = this._loadAudio.bind(this);
     this._seekTo = this._seekTo.bind(this);
 
-    if (this.props.responsive) {
-      this._handleResize = resizeThrottler(() => {
-        // pause playback for resize operation
-        if (this.props.playing) {
-          this._wavesurfer.pause();
-        }
-
-        // resize the waveform
-        this._wavesurfer.drawBuffer();
-
-        // We allow resize before file isloaded, since we can get wave data from outside,
-        // so there might not be a file loaded when resizing
-        if (this.state.isReady) {
-          // restore previous position
-          this._seekTo(this.props.pos);
-        }
-
-        // restore playback
-        if (this.props.playing) {
-          this._wavesurfer.play();
-        }
-      });
-    }
+    this._handleResize = resizeThrottler(() => {
+      if (this.state.isReady) {
+        this._wavesurfer.refresh();
+      }
+    });
   }
 
   componentDidMount() {


### PR DESCRIPTION
* Ensure `_handleResize` callback is always defined, even if  `responsive` prop is false initially. The callback might be needed  if we want to add an event listener later on in  `componentWillReceiveProps`.

* Use new `refresh` method to redraw  the wavefrom and also update the play progress without actually  seeking in the media file. There does not appear to be a need to
  pause while doing this. Wait for `isReady`, though, to prevent  calling refresh before `wavesurfer#init` has been called in  `componentDidMount`.

Once katspaugh/wavesurfer.js#1146 is merged and released, the peer dependency needs to be updated accordingly.