### PR TITLE
fixed React.PropTypes deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "peerDependencies": {
     "react": "^15.3.1",
+    "prop-types": "^15.5.10",
     "wavesurfer.js": "^1.1.11"
   },
   "devDependencies": {

--- a/src/plugins/minimap.js
+++ b/src/plugins/minimap.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 require('imports?define=>false,exports=>false!wavesurfer.js/dist/plugin/wavesurfer.minimap.min.js');
 
 class Minimap extends Component {

--- a/src/plugins/regions.js
+++ b/src/plugins/regions.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 require('imports?define=>false,exports=>false!wavesurfer.js/dist/plugin/wavesurfer.regions.min.js');
 
 const REGIONS_EVENTS = [

--- a/src/plugins/timeline.js
+++ b/src/plugins/timeline.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import assign from 'deep-assign';
 
 require('imports?define=>false,exports=>false!wavesurfer.js/dist/plugin/wavesurfer.timeline.min.js');

--- a/src/react-wavesurfer.js
+++ b/src/react-wavesurfer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import assign from 'deep-assign';
 
 const WaveSurfer = require('wavesurfer.js');


### PR DESCRIPTION
Fixes #39.

`Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`

From https://facebook.github.io/react/docs/typechecking-with-proptypes.html: 

> Note: React.PropTypes is deprecated as of React v15.5. Please use the prop-types library instead.